### PR TITLE
Fixed typo in episode 05 tree command output

### DIFF
--- a/_episodes/05-package-structure.md
+++ b/_episodes/05-package-structure.md
@@ -38,6 +38,7 @@ please review the [package setup] section of the lessons.
 ├── molecool                        <- Basic Python Package import file
 │   ├── __init__.py                 <- Basic Python Package import file
 │   ├── _version.py                 <- Automatic version control with Versioneer
+|   ├── functions.py                <- Manually add functions.py
 │   ├── data                        <- Sample additional data (non-code) which can be packaged. Just an example, delete in production
 │   │   ├── README.md
 │   │   └── look_and_say.dat


### PR DESCRIPTION
For some reason the typo in episode 01 was already fixed so I did not modify that file but I did fix the typo in episode 05
